### PR TITLE
bugfix: MultidatabaseMetadata.keyは通常の1件づつランダムなkeyではなく、Multidatabase.keyを明示的にセットする

### DIFF
--- a/Model/Behavior/Nc2ToNc3MultidatabaseBehavior.php
+++ b/Model/Behavior/Nc2ToNc3MultidatabaseBehavior.php
@@ -558,7 +558,7 @@ class Nc2ToNc3MultidatabaseBehavior extends Nc2ToNc3BaseBehavior {
 			$nc2Multidatabase['Nc2Multidatabase']['title_metadata_id']);
 
 		$data['MultidatabaseMetadata'] = [
-			//'key' => $nc3Multidatabase['Multidatabase']['key'], //
+			'key' => $nc3Multidatabase['Multidatabase']['key'], // bugfix: MultidatabaseMetadata.keyは通常の1件づつランダムなkeyではなく、Multidatabase.keyを明示的にセットする
 			'multidatabase_id' => $nc3MultidatabaseId,
 			'language_id' => $this->getLanguageIdFromNc2($model),
 			'name' => $nc2Metadatum['Nc2MultidatabaseMetadata']['name'],


### PR DESCRIPTION
ソース修正のみ。動作未確認

動作確認してからマージする。

https://github.com/NetCommons3/NetCommons3/issues/1555

